### PR TITLE
provide defaults for new DNA questions

### DIFF
--- a/src/template/package.json
+++ b/src/template/package.json
@@ -46,13 +46,16 @@
     "prod": {
       "port": 4000,
       "protocol": "http",
-      "entrypoint": "src/api/index.js"
+      "entrypoint": "src/api/index.js",
+      "type": "spa"
     },
     "dev": {
       "port": 4000,
       "protocol": "http",
       "entrypoint": "src/api/index.js",
-      "registry": ""
+      "registry": "",
+      "type": "spa",
+      "isPublic": false
     }
   },
   "proxy": "http://localhost:4000"


### PR DESCRIPTION
DNA added some additional questions recently, so right now CNA requires answers to these questions on first startup, and its not obvious that its an interactive prompt with both the UI and API processes running.